### PR TITLE
Fix undefined styleObj in createParser

### DIFF
--- a/src/createParser.js
+++ b/src/createParser.js
@@ -3,7 +3,7 @@ function createParser(matcher, replacer) {
   return string => {
     // * throw an error if not a string
     if (typeof string !== 'string') {
-      throw new TypeError(`expected an argument of type string, but got ${typeof styleObj}`);
+      throw new TypeError(`expected an argument of type string, but got ${typeof string}`);
     }
 
     // * if no match between string and matcher


### PR DESCRIPTION
If the parser created by `createParser` receives something that is not a string, it tries to throw an error:
```
throw new TypeError(`expected an argument of type string, but got ${typeof styleObj}`);
```
but `styleObj` is undefined here