### PR TITLE
chore: migrate CI from travis to GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+    push:
+        branches: master
+
+jobs:
+    validate:
+        runs-on: ubuntu-latest
+        strategy:
+          matrix:
+            node-version: ["16.x", "18.x", "20.x"]
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Setup node
+              uses: actions/setup-node@v3
+              with:
+                node-version: ${{ matrix.node-version }}
+            - run: npm run validate
+            - run: npm run test:report
+


### PR DESCRIPTION
This PR migrates the basic CI checks to GitHub Actions.  While this isn't necessary, I haven't kept up with Travis and don't expect to use it enough to justify relearning it.