### PR TITLE
fix(build): corrects the output of the build process (#28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,22 +2,22 @@
   "name": "style-object-to-css-string",
   "version": "0.0.0-development",
   "description": "A micro-package to convert style objects to css strings.  Inspired by extensive usage of styled-components.",
-  "main": "./dist/index.cjs.js",
-  "module": "./dist/index.es.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
   "exports": {
     ".": {
-      "require": "./dist/index.cjs.js",
-      "import": "./dist/index.es.js",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.mjs",
       "types": "./dist/main.d.ts"
     },
     "./parsers": {
-      "require": "./dist/parsers/index.cjs.js",
-      "import": "./dist/parsers/index.es.js",
+      "require": "./dist/parsers/index.cjs",
+      "import": "./dist/parsers/index.mjs",
       "types": "./dist/parsers/index.d.ts"
     },
     "./createParser": {
-      "require": "./dist/createParser/index.cjs.js",
-      "import": "./dist/createParser/index.es.js",
+      "require": "./dist/createParser/index.cjs",
+      "import": "./dist/createParser/index.mjs",
       "types": "./dist/createParser/index.d.ts"
     }
   },

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -9,12 +9,14 @@ export default {
             entry: {
                 parsers: resolve(__dirname, "src/parsers.js"),
                 createParser: resolve(__dirname, "src/createParser.js"),
-                main: resolve(__dirname, "src/objToString.js")
+                index: resolve(__dirname, "src/objToString.js")
             },
+            formats: ["esm", "cjs"],
             name: "styleObjectToCss",
             fileName: (format, entryAlias) => {
-                const fileName = `index.${format}.js`;
-                return entryAlias === "main" ? fileName : `${entryAlias}/${fileName}`;
+                const extension = format === "esm" ? "mjs" : "cjs";
+                const fileName = `index.${extension}`;
+                return entryAlias === "index" ? fileName : `${entryAlias}/${fileName}`;
             },
         },
         outDir: resolve(__dirname, "dist"),
@@ -26,7 +28,7 @@ export default {
     plugins: [dts({insertTypesEntry: true, beforeWriteFile(path, content) {
         const defaultFileName = basename(path);
         if (["main", "objToString"].some(name => defaultFileName.includes(name))) {
-            return {path, content}
+            return {filePath: path.replace(defaultFileName, "/index.d.ts"), content}
         }
         const fileName = defaultFileName.replace(".d.ts", "/index.d.ts");
         const newPath = path.replace(defaultFileName, fileName);


### PR DESCRIPTION
Imports were broken in consuming packages and it was narrowed down to the fact that the package.json fields weren't enough to make node/bundlers understand how to parse the file tree.

Fixes #27