### PR TITLE
fix(types): updates type resolution in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     ".": {
       "require": "./dist/index.cjs",
       "import": "./dist/index.mjs",
-      "types": "./dist/main.d.ts"
+      "types": "./dist/index.d.ts"
     },
     "./parsers": {
       "require": "./dist/parsers/index.cjs",


### PR DESCRIPTION
In updating the build output, I forgot to change the type resolution path.  This PR corrects that mistake