### PR TITLE
ci(release): adds manual dispatch option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - '[1-9].[x0-9].[x0-9]'
       - main
       - alpha
+  workflow_dispatch:
 
 permissions:
   contents: read # for checkout


### PR DESCRIPTION
I can't figure out some of this semantic release stuff, so I'm adding a manual trigger for releases via the `workflow_dispatch` event