### PR TITLE
fix(types): updates package.json for type resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "A micro-package to convert style objects to css strings.  Inspired by extensive usage of styled-components.",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "require": "./dist/index.cjs",
       "import": "./dist/index.mjs",
-      "types": "./dist/main.d.ts"
+      "types": "./dist/index.d.ts"
     },
     "./parsers": {
       "require": "./dist/parsers/index.cjs",


### PR DESCRIPTION
The `types` field was missing and `exports["."].types` fields pointed to the legacy filename still.  This PR updates both to point at the proper file in the distributed files.