### PR TITLE
doc: fix import package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Just in case, this package also exposes the ability to access or generate additi
 #### Without styled-components
 
 ```javascript
-import styleToCss from 'style-obj-to-css-string';
-// I now regret my choice in package name
+import styleToCss from 'style-object-to-css-string';
 
 const styles = {
   display: 'flex',
@@ -34,7 +33,7 @@ const styleString = styleToCss(styles);
 
 ```javascript
 import styled from 'styled-components';
-import styleToCss from 'style-obj-to-css-string';
+import styleToCss from 'style-object-to-css-string';
 
 const StyledThingy = styled.p`
   ${/* Place properties that you will allow to be overwritten here - typically stylistic properties */}


### PR DESCRIPTION
### Summary
- I am using: `"style-object-to-css-string": "^1.1.3",`
- The proper import syntax seems to work just fine. I was a little confused why the import shown in your readme doesn't work for me.

#### What works:
![image](https://github.com/Tbhesswebber/style-object-to-css-string/assets/38070918/45e31092-6e11-40d6-ac1a-bc596df0a155)


#### What doesn't:
![image](https://github.com/Tbhesswebber/style-object-to-css-string/assets/38070918/0474eca8-3291-4863-9b06-e1940419169a)
