### PR TITLE
ci(pr title): migrate to LTS action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,8 +16,6 @@ jobs:
     permissions:
       statuses: write 
     steps:
-      - uses: aslafy-z/conventional-pr-title-action@v3
-        with:
-          preset: conventional-changelog-angular
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,10 +11,9 @@ permissions:
   contents: read # for checkout
 
 jobs:
-  lint:
+  main:
+    name: Validate PR title
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write 
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:


### PR DESCRIPTION
The previously used [Action for PR title validation](https://github.com/aslafy-z/conventional-pr-title-action) is no longer being maintained and recommends that we use this one instead: https://github.com/amannn/action-semantic-pull-request