### PR TITLE
build(node): updates targets to be 18+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v4
             - name: Setup node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                 node-version: ${{ matrix.node-version }}
             - run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            node-version: ["18.x", "20.x", "22.x", "24.x"]
+            node-version: ["18.x", "20.x", "22.x"]
         steps:
             - name: Checkout
               uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            node-version: ["16.x", "18.x", "20.x"]
+            node-version: ["18.x", "20.x", "22.x", "24.x"]
         steps:
             - name: Checkout
               uses: actions/checkout@v4


### PR DESCRIPTION
This PR drops support for Node 16 and adds support for Node 22.